### PR TITLE
Add gitignore for OS and web build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Ignore macOS and Windows OS files
+.DS_Store
+Thumbs.db
+
+# Ignore node modules and build outputs
+node_modules/
+dist/


### PR DESCRIPTION
## Summary
- prevent OS files and build directories from being committed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68731e6a8afc832fac286e95601f80d5